### PR TITLE
fix: configure connection pool bounds and graceful shutdown

### DIFF
--- a/extensions/datastores/mongodb/client.ts
+++ b/extensions/datastores/mongodb/client.ts
@@ -25,10 +25,23 @@ export function createClientFactory(
       const client = new MongoClient(cfg.uri, {
         auth: { username: cfg.username, password },
         authSource: "admin",
+        maxPoolSize: cfg.maxPoolSize,
+        minPoolSize: 0,
+        maxIdleTimeMS: cfg.maxIdleTimeMS,
+        serverSelectionTimeoutMS: cfg.serverSelectionTimeoutMS,
       });
       await client.connect();
+
+      globalThis.addEventListener("beforeunload", () => {
+        client.close().catch(() => {});
+      });
+
       return { client, repoDir };
     })();
+    cached = cached.catch((err) => {
+      cached = undefined;
+      throw err;
+    });
     return cached;
   };
 }

--- a/extensions/datastores/mongodb/config.ts
+++ b/extensions/datastores/mongodb/config.ts
@@ -20,6 +20,15 @@ export const ConfigSchema = z.object({
     "Per-repo identifier used in collection prefixing (t_<tenant>_r_<namespace>_<purpose>)",
   ),
   defaultLockTtlMs: z.number().int().positive().default(30_000),
+  maxPoolSize: z.number().int().min(1).max(10_000).default(500).describe(
+    "Maximum number of connections in the driver pool. Default: 500",
+  ),
+  maxIdleTimeMS: z.number().int().min(0).default(60_000).describe(
+    "Close idle connections after this many milliseconds. 0 = never. Default: 60000 (1 min)",
+  ),
+  serverSelectionTimeoutMS: z.number().int().min(1000).default(5_000).describe(
+    "Timeout for server selection before failing. Default: 5000 (5 s)",
+  ),
 });
 
 export type MongoDatastoreConfig = z.infer<typeof ConfigSchema>;


### PR DESCRIPTION
## Summary

- Configure `MongoClient` pool options: `maxPoolSize` (default 500), `maxIdleTimeMS` (default 60s), `serverSelectionTimeoutMS` (default 5s) — previously used driver defaults (`maxIdleTimeMS=0`, connections never expire)
- Register `beforeunload` handler to call `client.close()` on process exit
- Clear cached connection promise on failure so next call retries instead of permanently caching the rejection

## Context

Under long-running `swamp serve`, the driver accumulated 5960 connections over 8 days because idle connections never closed and the client was never shut down. This pushed MongoDB to its 4g cgroup memory limit and caused healthcheck failures.

All new config fields are optional with backward-compatible defaults — existing setups work without changes.

Fixes #9

## Test plan

- [ ] Verify existing `swamp datastore setup` works without specifying new config fields
- [ ] Run `swamp serve` for extended period, monitor `connectionCount` in MongoDB logs
- [ ] Verify connections close after 60s idle
- [ ] Verify `client.close()` fires on process exit
- [ ] Verify connection failure doesn't permanently cache the rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)